### PR TITLE
Add pypi publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,28 @@
+name: "Publish"
+
+on:
+  release:
+    types: ["published"]
+
+jobs:
+  run:
+    name: "Build and publish release"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Build
+        run: uv build
+
+      - name: Publish
+        run: uv publish -t ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION


### Summarized changes
### Summary of Main Changes
This pull request introduces a new GitHub Actions workflow named "Publish," which is triggered when a release is published. The workflow automates the process of building and publishing a Python package using the `uv` toolchain, ensuring that the code can be easily deployed to a package repository.

### Key Modifications by Category
- **Features**: 
  - Added a new workflow file (`publish.yaml`) in the GitHub Actions directory.
  - Configured the workflow to run on the `release` event when a release is published.
  - Included steps for checking out the code, installing dependencies, building the project, and publishing it to a repository using provided secrets.

### Potential Concerns or Areas for Attention
- **Security**: Ensure that the `PYPI_TOKEN` secret used in the publish step is correctly set up in the repository settings to prevent unauthorized access.
- **Error Handling**: The current workflow does not include error handling or notifications for failed steps; consider adding checks to improve robustness.
- **Dependencies**: Verify that using `uv` for installation and publishing does not introduce compatibility issues with existing project dependencies or workflows.